### PR TITLE
Fix anchor links in table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ It is conceived as a valuable resource in its own right, and as Research and Dev
 
 ## Contents
 
-- [CO2 emissions trackers and green website raters](https://github.com/Adora-Foundation/awesome-green-extensions/edit/main/README.md#co2-emissions-trackers-and-green-website-raters)
-- [Browser energy consumption optimisers](https://github.com/Adora-Foundation/awesome-green-extensions/edit/main/README.md#browser-energy-consumption-optimisers)
-- [Carbon offset generators](https://github.com/Adora-Foundation/awesome-green-extensions/edit/main/README.md#carbon-offset-generators)
-- [Graceful degradation tools](https://github.com/Adora-Foundation/awesome-green-extensions/edit/main/README.md#graceful-degradation-tools)
+- [CO2 emissions trackers and green website raters](#co2-emissions-trackers-and-green-website-raters)
+- [Browser energy consumption optimisers](#browser-energy-consumption-optimisers)
+- [Carbon offset generators](#carbon-offset-generators)
+- [Graceful degradation tools](#graceful-degradation-tools)
 
 ## CO2 emissions trackers and green website raters
 


### PR DESCRIPTION
Right now clicking the links takes you to a "create a fork" page, since they go to the file’s edit view. Instead, we want them to take people further down the README directly on https://github.com/Adora-Foundation/awesome-green-extensions.